### PR TITLE
Do not read stdout/stderr as binary data

### DIFF
--- a/agent/shell/job.rb
+++ b/agent/shell/job.rb
@@ -98,7 +98,7 @@ module MCollective
         end
 
         def stdout(offset = 0)
-          fh = File.new("#{state_directory}/stdout", 'rb')
+          fh = File.new("#{state_directory}/stdout", 'r')
           fh.seek(offset, IO::SEEK_SET)
           out = fh.read
           fh.close
@@ -106,7 +106,7 @@ module MCollective
         end
 
         def stderr(offset = 0)
-          fh = File.new("#{state_directory}/stderr", 'rb')
+          fh = File.new("#{state_directory}/stderr", 'r')
           fh.seek(offset, IO::SEEK_SET)
           err = fh.read
           fh.close

--- a/spec/unit/agent/shell/job_spec.rb
+++ b/spec/unit/agent/shell/job_spec.rb
@@ -70,7 +70,7 @@ module MCollective
             state_directory = job.send(:state_directory)
 
             filehandle = mock('filehandle')
-            File.expects(:new).with("#{state_directory}/stdout", 'rb').returns(filehandle)
+            File.expects(:new).with("#{state_directory}/stdout", 'r').returns(filehandle)
             filehandle.expects(:seek).with(0, IO::SEEK_SET)
             filehandle.expects(:read).returns("some data")
             filehandle.expects(:close)
@@ -82,7 +82,7 @@ module MCollective
             state_directory = job.send(:state_directory)
 
             filehandle = mock('filehandle')
-            File.expects(:new).with("#{state_directory}/stdout", 'rb').returns(filehandle)
+            File.expects(:new).with("#{state_directory}/stdout", 'r').returns(filehandle)
             filehandle.expects(:seek).with(5, IO::SEEK_SET)
             filehandle.expects(:read).returns("some data at an offset")
             filehandle.expects(:close)
@@ -96,7 +96,7 @@ module MCollective
             state_directory = job.send(:state_directory)
 
             filehandle = mock('filehandle')
-            File.expects(:new).with("#{state_directory}/stderr", 'rb').returns(filehandle)
+            File.expects(:new).with("#{state_directory}/stderr", 'r').returns(filehandle)
             filehandle.expects(:seek).with(0, IO::SEEK_SET)
             filehandle.expects(:read).returns("some data")
             filehandle.expects(:close)
@@ -108,7 +108,7 @@ module MCollective
             state_directory = job.send(:state_directory)
 
             filehandle = mock('filehandle')
-            File.expects(:new).with("#{state_directory}/stderr", 'rb').returns(filehandle)
+            File.expects(:new).with("#{state_directory}/stderr", 'r').returns(filehandle)
             filehandle.expects(:seek).with(5, IO::SEEK_SET)
             filehandle.expects(:read).returns("some data at an offset")
             filehandle.expects(:close)


### PR DESCRIPTION
When reading a file in binary mode, Ruby:
  1. Does not convert CR+LF to LF on windows;
  2. Force the encoding to ASCII-8BIT.

When attempting to print a String, ruby convert it to the encoding of
the teminal, generaly UTF-8, but arbitrary binary data cannot be
converted, and any non-ASCII char (with the most significant bit set to
1) will raise an Encoding::UndefinedConversionError exception, e.g.:

> "\xC3" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)

Update the way we read stdout/stderr to avoid forcing encoding (we
assume the command was using the same encoding as the one we are reading
it's output with, and therefore that the output will be processable).
This fix the behavior of the shell agent when output contains
non-ASCCI-7BIT chars.
