### PR TITLE
(#18) Remove deprecated File.exists? to support Ruby 3.2

### DIFF
--- a/agent/shell/job.rb
+++ b/agent/shell/job.rb
@@ -44,12 +44,12 @@ module MCollective
             @handle = handle
 
             commandfile = "#{state_directory}/command"
-            if File.exists?(commandfile)
+            if File.exist?(commandfile)
               @command = IO.read(commandfile).chomp
             end
 
             pidfile = "#{state_directory}/pid"
-            if File.exists?(pidfile)
+            if File.exist?(pidfile)
               @pid = Integer(IO.read(pidfile))
             end
 
@@ -83,13 +83,13 @@ module MCollective
           end
 
           # busy wait for a pid or error file
-          while !File.exists?("#{state_directory}/pid") && !File.exists?("#{state_directory}/error")
+          while !File.exist?("#{state_directory}/pid") && !File.exist?("#{state_directory}/error")
             sleep 0.1
           end
 
           ::Process.detach(manager)
 
-          if File.exists?("#{state_directory}/pid")
+          if File.exist?("#{state_directory}/pid")
             @pid = Integer(IO.read("#{state_directory}/pid"))
           else
             # we must have an error file
@@ -114,17 +114,17 @@ module MCollective
         end
 
         def status
-          if File.exists?("#{state_directory}/error")
+          if File.exist?("#{state_directory}/error")
             # Process failed to start
             return :failed
           end
 
-          if !File.exists?("#{state_directory}/pid")
+          if !File.exist?("#{state_directory}/pid")
             # We haven't started yet
             return :starting
           end
 
-          if File.exists?("#{state_directory}/exitstatus")
+          if File.exist?("#{state_directory}/exitstatus")
             # The manager has written out the exitstatus, so the process is done
             return :stopped
           end
@@ -161,7 +161,7 @@ module MCollective
 
         def get_exitcode
           statusfile = "#{state_directory}/exitstatus"
-          if File.exists?(statusfile)
+          if File.exist?(statusfile)
             status = Integer(IO.read(statusfile))
             @signal = status & 0xff
             @exitcode = status >> 8

--- a/spec/unit/agent/shell/job_spec.rb
+++ b/spec/unit/agent/shell/job_spec.rb
@@ -54,7 +54,7 @@ module MCollective
               :out => :close,
               :err => :close,
             }).returns(53)
-            File.expects(:exists?).with("#{state_directory}/pid").returns(true).twice
+            File.expects(:exist?).with("#{state_directory}/pid").returns(true).twice
             IO.expects(:read).with("#{state_directory}/pid").returns("54\n")
             job.start_command('echo foo')
             job.pid.should == 54
@@ -124,27 +124,27 @@ module MCollective
           end
 
           it 'should be :failed if there is an error file' do
-            File.expects(:exists?).with('test/error').returns(true)
+            File.expects(:exist?).with('test/error').returns(true)
             job.status.should == :failed
           end
 
           it 'should be :starting if there is no pid' do
-            File.expects(:exists?).with('test/error').returns(false)
-            File.expects(:exists?).with('test/pid').returns(false)
+            File.expects(:exist?).with('test/error').returns(false)
+            File.expects(:exist?).with('test/pid').returns(false)
             job.status.should == :starting
           end
 
           it 'should be :stopped is there is an exitstatus' do
-            File.expects(:exists?).with('test/error').returns(false)
-            File.expects(:exists?).with('test/pid').returns(true)
-            File.expects(:exists?).with('test/exitstatus').returns(true)
+            File.expects(:exist?).with('test/error').returns(false)
+            File.expects(:exist?).with('test/pid').returns(true)
+            File.expects(:exist?).with('test/exitstatus').returns(true)
             job.status.should == :stopped
           end
 
           it 'should be :running if there is no exitstatus' do
-            File.expects(:exists?).with('test/error').returns(false)
-            File.expects(:exists?).with('test/pid').returns(true)
-            File.expects(:exists?).with('test/exitstatus').returns(false)
+            File.expects(:exist?).with('test/error').returns(false)
+            File.expects(:exist?).with('test/pid').returns(true)
+            File.expects(:exist?).with('test/exitstatus').returns(false)
             job.status.should == :running
           end
         end


### PR DESCRIPTION
This is needed for Puppet 8 support.

Closes: #18